### PR TITLE
Add GitHub Copilot CLI as a supported tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Claude Code Contained is a bash-based containerization wrapper that runs AI coding assistants (Claude, Codex, Gemini, Vibe) inside an Apple Containers sandbox with persistent state. It enables isolated, repeatable sessions on macOS with support for multi-project workflows and host service access.
+Claude Code Contained is a bash-based containerization wrapper that runs AI coding assistants (Claude, Codex, Copilot, Gemini, Vibe) inside an Apple Containers sandbox with persistent state. It enables isolated, repeatable sessions on macOS with support for multi-project workflows and host service access.
 
 ## Build and Run Commands
 
@@ -17,6 +17,7 @@ claude-contained
 
 # Run other tools
 claude-contained -t codex .
+claude-contained -t copilot .
 claude-contained -t gemini .
 claude-contained -t vibe .
 
@@ -41,7 +42,7 @@ claude-contained -N .
 
 - **claude-docked** - Docker equivalent of claude-contained. **Must be kept in sync with claude-contained** to maintain feature parity. Both scripts share the same flag interface and behavior.
 
-- **Dockerfile** - Builds on Node 20 (Debian Bookworm). Installs JetBrains Runtime 25, HotswapAgent, AI CLI tools (Claude Code, OpenAI Codex, Google Gemini CLI, Mistral Vibe), ripgrep, Python 3. Creates entrypoint.sh that configures `host.local` for host service access, matches host UID/GID, and sets up path parity.
+- **Dockerfile** - Builds on Node 20 (Debian Bookworm). Installs JetBrains Runtime 25, HotswapAgent, AI CLI tools (Claude Code, OpenAI Codex, GitHub Copilot, Google Gemini CLI, Mistral Vibe), ripgrep, Python 3. Creates entrypoint.sh that configures `host.local` for host service access, matches host UID/GID, and sets up path parity.
 
 - **.mcp.json** - MCP server configuration, notably enabling Figma Desktop MCP via `host.local:3845`.
 
@@ -50,7 +51,7 @@ claude-contained -N .
 - **Full path parity**: Directories mounted at their original host paths (e.g., `/Users/me/project` → `/Users/me/project`)
 - **HOME parity**: Container HOME matches host HOME for consistent behavior
 - **UID/GID matching**: Container user matches host user IDs for proper file permissions
-- **State sharing**: Tool configs (`~/.claude`, `~/.codex`, `~/.gemini`, `~/.vibe`), Maven cache (`~/.m2`), and Vaadin state (`~/.vaadin`) bind-mounted from host
+- **State sharing**: Tool configs (`~/.claude`, `~/.codex`, `~/.copilot`, `~/.gemini`, `~/.vibe`), Maven cache (`~/.m2`), and Vaadin state (`~/.vaadin`) bind-mounted from host
 - **SSH agent forwarding**: Disabled by default for security; enable with `-S/--ssh` flag (required for `git push` to SSH remotes)
 - Host services accessible via `host.local` hostname (resolved from container gateway IP)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,7 @@ RUN set -eux; \
 
 # ---- Language Servers + AI CLIs --------------------------------------------
 RUN npm install -g \
+    @github/copilot \
     @google/gemini-cli \
     @openai/codex \
     typescript \

--- a/claude-contained
+++ b/claude-contained
@@ -10,7 +10,7 @@ Description:
   Runs AI coding assistants inside an Apple Containers sandbox.
 
 Options:
-  -t, --tool TOOL    AI tool to run: claude (default), codex, gemini, vibe
+  -t, --tool TOOL    AI tool to run: claude (default), codex, copilot, gemini, vibe
   -H PORT[:HOSTPORT] Forward host port to container localhost (can be repeated)
   -p HOST:CONTAINER  Publish container port to host (can be repeated)
   -s, --shell        Start a bash shell instead of the AI tool (for debugging)
@@ -25,13 +25,14 @@ Behavior:
   - If no directories are provided, defaults to the current directory.
   - Directories are mounted at their original host paths for full path parity.
   - Additional directories are automatically added via --add-dir (claude, codex only).
-  - Tool configs (~/.claude, ~/.codex, ~/.gemini, ~/.vibe), Maven cache (~/.m2), and Vaadin state (~/.vaadin) are bind-mounted.
+  - Tool configs (~/.claude, ~/.codex, ~/.copilot, ~/.gemini, ~/.vibe), Maven cache (~/.m2), and Vaadin state (~/.vaadin) are bind-mounted.
   - SSH agent forwarding is disabled by default; use --ssh to enable (for git push).
   - Git worktrees are detected; main repository is included for full git access.
 
 Examples:
   claude-contained                     # Run claude in current directory
   claude-contained -t codex .          # Run codex instead
+  claude-contained -t copilot .        # Run copilot instead
   claude-contained -t gemini .         # Run gemini instead
   claude-contained -t vibe .           # Run vibe instead
   claude-contained . ../other/project  # Mount extra directories
@@ -80,7 +81,7 @@ build_attach_cmd() {
   if [[ $yolo_mode -eq 1 ]]; then
     case "$tool" in
       claude) attach_cmd+=(--dangerously-skip-permissions) ;;
-      codex|gemini) attach_cmd+=(--yolo) ;;
+      codex|copilot|gemini) attach_cmd+=(--yolo) ;;
       vibe) echo "Warning: vibe does not support yolo mode" >&2 ;;
     esac
   fi
@@ -341,13 +342,14 @@ HOST_HOME="$HOME"
 HOST_CLAUDE_DIR="${HOST_HOME}/.claude"
 HOST_CODEX_DIR="${HOST_HOME}/.codex"
 HOST_GEMINI_DIR="${HOST_HOME}/.gemini"
+HOST_COPILOT_DIR="${HOST_HOME}/.copilot"
 HOST_VIBE_DIR="${HOST_HOME}/.vibe"
 HOST_M2_DIR="${HOST_HOME}/.m2"
 HOST_VAADIN_DIR="${HOST_HOME}/.vaadin"
 HOST_GITCONFIG="${HOST_HOME}/.gitconfig"
 
 # Ensure persistent directories exist on host
-mkdir -p "${HOST_CLAUDE_DIR}" "${HOST_CODEX_DIR}" "${HOST_GEMINI_DIR}" "${HOST_VIBE_DIR}" "${HOST_M2_DIR}" "${HOST_VAADIN_DIR}"
+mkdir -p "${HOST_CLAUDE_DIR}" "${HOST_CODEX_DIR}" "${HOST_COPILOT_DIR}" "${HOST_GEMINI_DIR}" "${HOST_VIBE_DIR}" "${HOST_M2_DIR}" "${HOST_VAADIN_DIR}"
 
 # Build container args
 CLAUDE_MEMORY="${CLAUDE_MEMORY:-8g}"
@@ -370,6 +372,7 @@ container_argv=(
   ${AI_GH_TOKEN:+-e "GH_TOKEN=${AI_GH_TOKEN}"}
   --mount "type=bind,src=${HOST_CLAUDE_DIR},dst=${HOST_HOME}/.claude"
   --mount "type=bind,src=${HOST_CODEX_DIR},dst=${HOST_HOME}/.codex"
+  --mount "type=bind,src=${HOST_COPILOT_DIR},dst=${HOST_HOME}/.copilot"
   --mount "type=bind,src=${HOST_GEMINI_DIR},dst=${HOST_HOME}/.gemini"
   --mount "type=bind,src=${HOST_VIBE_DIR},dst=${HOST_HOME}/.vibe"
   --mount "type=bind,src=${HOST_M2_DIR},dst=${HOST_HOME}/.m2"
@@ -442,6 +445,10 @@ case "$tool" in
     tool_argv=(codex)
     [[ $yolo_mode -eq 1 ]] && tool_argv+=(--yolo)
     ;;
+  copilot)
+    tool_argv=(copilot)
+    [[ $yolo_mode -eq 1 ]] && tool_argv+=(--yolo)
+    ;;
   gemini)
     tool_argv=(gemini)
     [[ $yolo_mode -eq 1 ]] && tool_argv+=(--yolo)
@@ -452,7 +459,7 @@ case "$tool" in
     ;;
   *)
     echo "Unknown tool: $tool" >&2
-    echo "Supported tools: claude, codex, gemini, vibe" >&2
+    echo "Supported tools: claude, codex, copilot, gemini, vibe" >&2
     exit 1
     ;;
 esac

--- a/claude-docked
+++ b/claude-docked
@@ -10,7 +10,7 @@ Description:
   Runs AI coding assistants inside a Docker container.
 
 Options:
-  -t, --tool TOOL    AI tool to run: claude (default), codex, gemini, vibe
+  -t, --tool TOOL    AI tool to run: claude (default), codex, copilot, gemini, vibe
   -H PORT[:HOSTPORT] Forward host port to container localhost (can be repeated)
   -p HOST:CONTAINER  Publish container port to host (can be repeated)
   -s, --shell        Start a bash shell instead of the AI tool (for debugging)
@@ -25,13 +25,14 @@ Behavior:
   - If no directories are provided, defaults to the current directory.
   - Directories are mounted at their original host paths for full path parity.
   - Additional directories are automatically added via --add-dir (claude, codex only).
-  - Tool configs (~/.claude, ~/.codex, ~/.gemini, ~/.vibe), Maven cache (~/.m2), and Vaadin state (~/.vaadin) are bind-mounted.
+  - Tool configs (~/.claude, ~/.codex, ~/.copilot, ~/.gemini, ~/.vibe), Maven cache (~/.m2), and Vaadin state (~/.vaadin) are bind-mounted.
   - SSH agent forwarding is disabled by default; use --ssh to enable (for git push).
   - Git worktrees are detected; main repository is included for full git access.
 
 Examples:
   claude-docked                      # Run claude in current directory
   claude-docked -t codex .           # Run codex instead
+  claude-docked -t copilot .         # Run copilot instead
   claude-docked -t gemini .          # Run gemini instead
   claude-docked -t vibe .            # Run vibe instead
   claude-docked . ../other/project   # Mount extra directories
@@ -83,7 +84,7 @@ build_attach_cmd() {
   if [[ $yolo_mode -eq 1 ]]; then
     case "$tool" in
       claude) attach_cmd+=(--dangerously-skip-permissions) ;;
-      codex|gemini) attach_cmd+=(--yolo) ;;
+      codex|copilot|gemini) attach_cmd+=(--yolo) ;;
       vibe) echo "Warning: vibe does not support yolo mode" >&2 ;;
     esac
   fi
@@ -348,13 +349,14 @@ HOST_HOME="$HOME"
 HOST_CLAUDE_DIR="${HOST_HOME}/.claude"
 HOST_CODEX_DIR="${HOST_HOME}/.codex"
 HOST_GEMINI_DIR="${HOST_HOME}/.gemini"
+HOST_COPILOT_DIR="${HOST_HOME}/.copilot"
 HOST_VIBE_DIR="${HOST_HOME}/.vibe"
 HOST_M2_DIR="${HOST_HOME}/.m2"
 HOST_VAADIN_DIR="${HOST_HOME}/.vaadin"
 HOST_GITCONFIG="${HOST_HOME}/.gitconfig"
 
 # Ensure persistent directories exist on host
-mkdir -p "${HOST_CLAUDE_DIR}" "${HOST_CODEX_DIR}" "${HOST_GEMINI_DIR}" "${HOST_VIBE_DIR}" "${HOST_M2_DIR}" "${HOST_VAADIN_DIR}"
+mkdir -p "${HOST_CLAUDE_DIR}" "${HOST_CODEX_DIR}" "${HOST_COPILOT_DIR}" "${HOST_GEMINI_DIR}" "${HOST_VIBE_DIR}" "${HOST_M2_DIR}" "${HOST_VAADIN_DIR}"
 
 # Build container args
 CLAUDE_MEMORY="${CLAUDE_MEMORY:-8g}"
@@ -377,6 +379,7 @@ container_argv=(
   ${AI_GH_TOKEN:+-e "GH_TOKEN=${AI_GH_TOKEN}"}
   --mount "type=bind,src=${HOST_CLAUDE_DIR},dst=${HOST_HOME}/.claude"
   --mount "type=bind,src=${HOST_CODEX_DIR},dst=${HOST_HOME}/.codex"
+  --mount "type=bind,src=${HOST_COPILOT_DIR},dst=${HOST_HOME}/.copilot"
   --mount "type=bind,src=${HOST_GEMINI_DIR},dst=${HOST_HOME}/.gemini"
   --mount "type=bind,src=${HOST_VIBE_DIR},dst=${HOST_HOME}/.vibe"
   --mount "type=bind,src=${HOST_M2_DIR},dst=${HOST_HOME}/.m2"
@@ -466,6 +469,10 @@ case "$tool" in
     tool_argv=(codex)
     [[ $yolo_mode -eq 1 ]] && tool_argv+=(--yolo)
     ;;
+  copilot)
+    tool_argv=(copilot)
+    [[ $yolo_mode -eq 1 ]] && tool_argv+=(--yolo)
+    ;;
   gemini)
     tool_argv=(gemini)
     [[ $yolo_mode -eq 1 ]] && tool_argv+=(--yolo)
@@ -476,7 +483,7 @@ case "$tool" in
     ;;
   *)
     echo "Unknown tool: $tool" >&2
-    echo "Supported tools: claude, codex, gemini, vibe" >&2
+    echo "Supported tools: claude, codex, copilot, gemini, vibe" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
Install @github/copilot in Dockerfile and add copilot support to both claude-contained and claude-docked with config dir mounting (~/.copilot), yolo mode (--yolo), and help text updates.