### PR TITLE
Expose all JBR binaries via /usr/local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -209,12 +209,13 @@ USER root
 
 # ---- Symlink key binaries to /usr/local/bin ---------------------------------
 # Codex runs `bash -lc` which sources /etc/profile, clobbering inherited PATH.
-# Symlinks ensure java/mvn/jbang are found via the default Debian PATH.
-RUN ln -sf /opt/jbr/bin/java /usr/local/bin/java \
- && ln -sf /opt/jbr/bin/javac /usr/local/bin/javac \
- && ln -sf /opt/jbr/bin/jar /usr/local/bin/jar \
- && ln -sf /home/dev/.sdkman/candidates/maven/current/bin/mvn /usr/local/bin/mvn \
- && ln -sf /home/dev/.sdkman/candidates/jbang/current/bin/jbang /usr/local/bin/jbang
+# Symlinks ensure JBR/Maven/JBang binaries are found via the default Debian PATH.
+RUN set -eux; \
+    for bin in /opt/jbr/bin/*; do \
+      ln -sf "$bin" "/usr/local/bin/$(basename "$bin")"; \
+    done; \
+    ln -sf /home/dev/.sdkman/candidates/maven/current/bin/mvn /usr/local/bin/mvn; \
+    ln -sf /home/dev/.sdkman/candidates/jbang/current/bin/jbang /usr/local/bin/jbang
 
 # ---- Entrypoint (host.local setup + path parity) ---------------------------
 RUN cat <<'EOF' > /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
Symlink every binary in /opt/jbr/bin/ so tools like jshell, jdeps, jlink, jmod, jstack, jcmd, jmap, jps, keytool, and javadoc are available alongside java/javac/jar regardless of how PATH is set.