### PR TITLE
Condense worktree auto-lock prompt and add -W to skip it

### DIFF
--- a/claude-contained
+++ b/claude-contained
@@ -17,6 +17,7 @@ Options:
   -s, --shell        Start a bash shell instead of the AI tool (for debugging)
   -S, --ssh          Enable SSH agent forwarding (for git push)
   -w, --worktree     Auto-include git worktree's main repository (skip prompt)
+  -W, --lock-worktrees  Auto-lock hidden linked worktrees (skip prompt)
   -y, --yolo         Skip all permission prompts (tool-specific flag)
   -N, --contained-node-modules  Use container-specific node_modules (skip prompt)
   --readonly-extras  Mount all extra dirs read-only (suffix overrides per-path)
@@ -193,6 +194,7 @@ fi
 shell_mode=0
 ssh_mode=0
 worktree_mode=0
+lock_worktrees=0
 yolo_mode=0
 contained_node_modules=0
 attach_mode=0
@@ -240,6 +242,10 @@ while [[ "${1:-}" == -* ]]; do
       ;;
     -w|--worktree)
       worktree_mode=1
+      shift
+      ;;
+    -W|--lock-worktrees)
+      lock_worktrees=1
       shift
       ;;
     -y|--yolo)
@@ -668,14 +674,12 @@ maybe_offer_worktree_locks() {
 
   [[ ${#hidden_worktrees[@]} -gt 0 ]] || return 0
 
-  echo "Some linked git worktrees are not mounted into the container:"
-  for wt_path in "${hidden_worktrees[@]}"; do
-    echo "  ${wt_path}"
-  done
-  echo "Git inside the container can see ${repo_root}/.git/worktrees, but not those paths."
-  echo "A git worktree prune from inside the container could treat them as stale."
-  echo "The launcher can auto-lock them now and remove its owner when this container exits."
-  read -p "Auto-lock these worktrees while this container runs? [Y/n] " answer
+  echo "${#hidden_worktrees[@]} linked worktree(s) under ${repo_root} hidden from container (prune risk)."
+  if [[ ${lock_worktrees:-0} -eq 1 ]]; then
+    answer="Y"
+  else
+    read -p "Auto-lock them while this container runs? [Y/n] " answer
+  fi
   case "${answer:-Y}" in
     [Yy]* )
       auto_worktree_lock_repo="$repo_root"

--- a/claude-docked
+++ b/claude-docked
@@ -17,6 +17,7 @@ Options:
   -s, --shell        Start a bash shell instead of the AI tool (for debugging)
   -S, --ssh          Enable SSH agent forwarding (for git push)
   -w, --worktree     Auto-include git worktree's main repository (skip prompt)
+  -W, --lock-worktrees  Auto-lock hidden linked worktrees (skip prompt)
   -y, --yolo         Skip all permission prompts (tool-specific flag)
   -N, --contained-node-modules  Use container-specific node_modules (skip prompt)
   --readonly-extras  Mount all extra dirs read-only (suffix overrides per-path)
@@ -196,6 +197,7 @@ fi
 shell_mode=0
 ssh_mode=0
 worktree_mode=0
+lock_worktrees=0
 yolo_mode=0
 contained_node_modules=0
 attach_mode=0
@@ -243,6 +245,10 @@ while [[ "${1:-}" == -* ]]; do
       ;;
     -w|--worktree)
       worktree_mode=1
+      shift
+      ;;
+    -W|--lock-worktrees)
+      lock_worktrees=1
       shift
       ;;
     -y|--yolo)
@@ -675,14 +681,12 @@ maybe_offer_worktree_locks() {
 
   [[ ${#hidden_worktrees[@]} -gt 0 ]] || return 0
 
-  echo "Some linked git worktrees are not mounted into the container:"
-  for wt_path in "${hidden_worktrees[@]}"; do
-    echo "  ${wt_path}"
-  done
-  echo "Git inside the container can see ${repo_root}/.git/worktrees, but not those paths."
-  echo "A git worktree prune from inside the container could treat them as stale."
-  echo "The launcher can auto-lock them now and remove its owner when this container exits."
-  read -p "Auto-lock these worktrees while this container runs? [Y/n] " answer
+  echo "${#hidden_worktrees[@]} linked worktree(s) under ${repo_root} hidden from container (prune risk)."
+  if [[ ${lock_worktrees:-0} -eq 1 ]]; then
+    answer="Y"
+  else
+    read -p "Auto-lock them while this container runs? [Y/n] " answer
+  fi
   case "${answer:-Y}" in
     [Yy]* )
       auto_worktree_lock_repo="$repo_root"


### PR DESCRIPTION
Collapse the multi-line hidden-worktree warning to a single summary line and add -W/--lock-worktrees to auto-accept the prompt non-interactively.