### PR TITLE
Add Rust toolchain + just to container, persist ~/.cargo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ claude-contained -N .
 
 - **claude-docked** - Docker equivalent of claude-contained. **Must be kept in sync with claude-contained** to maintain feature parity. Both scripts share the same flag interface and behavior.
 
-- **Dockerfile** - Builds on Node 20 (Debian Bookworm). Installs JetBrains Runtime 25, HotswapAgent, AI CLI tools (Claude Code, OpenAI Codex, GitHub Copilot, Google Gemini CLI, Mistral Vibe), ripgrep, Python 3. Creates entrypoint.sh that configures `host.local` for host service access, matches host UID/GID, and sets up path parity.
+- **Dockerfile** - Builds on Node 20 (Debian Bookworm). Installs JetBrains Runtime 25, HotswapAgent, AI CLI tools (Claude Code, OpenAI Codex, GitHub Copilot, Google Gemini CLI, Mistral Vibe), the Rust toolchain (rustup: cargo/rustc/clippy/rustfmt) + `just`, ripgrep, Python 3. Creates entrypoint.sh that configures `host.local` for host service access, matches host UID/GID, and sets up path parity. Rustup lives in `/opt/rust` (shared, on PATH); entrypoint.sh redirects `CARGO_HOME` to the persisted `~/.cargo` mount so the crate registry survives across runs.
 
 - **.mcp.json** - MCP server configuration, notably enabling Figma Desktop MCP via `host.local:3845`.
 
@@ -51,7 +51,7 @@ claude-contained -N .
 - **Full path parity**: Directories mounted at their original host paths (e.g., `/Users/me/project` → `/Users/me/project`)
 - **HOME parity**: Container HOME matches host HOME for consistent behavior
 - **UID/GID matching**: Container user matches host user IDs for proper file permissions
-- **State sharing**: Tool configs (`~/.claude`, `~/.codex`, `~/.copilot`, `~/.gemini`, `~/.vibe`), Maven cache (`~/.m2`), and Vaadin state (`~/.vaadin`) bind-mounted from host
+- **State sharing**: Tool configs (`~/.claude`, `~/.codex`, `~/.copilot`, `~/.gemini`, `~/.vibe`), Maven cache (`~/.m2`), Vaadin state (`~/.vaadin`), and Cargo cache (`~/.cargo`) bind-mounted from host
 - **Shared skills**: `--share-skills=DIR` is opt-in and has no default. It requires a full path and mounts `DIR` as each tool's skills directory. Codex gets a nested mount for host `~/.codex/skills/.system` so built-ins remain visible while new installs write to `DIR`.
 - **SSH agent forwarding**: Disabled by default for security; enable with `-S/--ssh` flag (required for `git push` to SSH remotes)
 - Host services accessible via `host.local` hostname (resolved from container gateway IP)

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN set -eux; \
     BASE_PACKAGES=" \
       git openssh-client ca-certificates ripgrep jq \
       curl bash xz-utils unzip tzdata \
+      build-essential pkg-config \
       python3 python3-pip python3-venv \
       iproute2 gosu socat \
       libasound2 libatk-bridge2.0-0 libatk1.0-0 libatspi2.0-0 \
@@ -137,6 +138,54 @@ RUN set -eux; \
     chmod +x /usr/local/bin/bun; \
     rm -rf /tmp/bun.zip /tmp/bun-linux-${BUN_ARCH}; \
     bun --version
+
+# ---- Install Rust toolchain (rustup) ---------------------------------------
+# Rust projects need a real toolchain (cargo build/test, cargo insta snapshots,
+# clippy, rustfmt, ...). Install rustup into a shared system location so every
+# user -- including the dynamic-UID dev user -- can use it. Linking needs a C
+# toolchain (cc/ld) -- provided by build-essential in the base packages above.
+# CARGO_HOME here holds
+# the rustup proxy binaries (cargo/rustc/...) and the default crate cache; at
+# runtime entrypoint.sh redirects CARGO_HOME to the persisted ~/.cargo mount
+# while these proxies stay reachable on PATH.
+ENV RUSTUP_HOME=/opt/rust/rustup \
+    CARGO_HOME=/opt/rust/cargo \
+    PATH=/opt/rust/cargo/bin:$PATH
+ARG RUST_VERSION=stable
+RUN set -eux; \
+    curl -fsSL https://sh.rustup.rs -o /tmp/rustup-init.sh; \
+    sh /tmp/rustup-init.sh -y --no-modify-path --profile minimal \
+      --default-toolchain "${RUST_VERSION}"; \
+    rm -f /tmp/rustup-init.sh; \
+    rustup component add clippy rustfmt; \
+    # World-writable so cargo can populate its cache even without the ~/.cargo mount
+    chmod -R a+rwX "$CARGO_HOME"; \
+    chmod -R a+rX "$RUSTUP_HOME"; \
+    rustc --version; \
+    cargo --version
+
+# ---- Install just (command runner) -----------------------------------------
+# Prebuilt static musl binary (works on both amd64 and arm64 Debian).
+ARG JUST_VERSION=latest
+RUN set -eux; \
+    ARCH="$(dpkg --print-architecture)"; \
+    case "$ARCH" in \
+      arm64)  JUST_ARCH="aarch64" ;; \
+      amd64)  JUST_ARCH="x86_64" ;; \
+      *)      echo "Unsupported architecture: $ARCH"; exit 1 ;; \
+    esac; \
+    if [ "$JUST_VERSION" = "latest" ]; then \
+      JUST_VERSION=$(curl -fsSL https://api.github.com/repos/casey/just/releases/latest | grep -oP '"tag_name": "\K[^"]+'); \
+    fi; \
+    echo "Installing just ${JUST_VERSION}"; \
+    URL="https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-${JUST_ARCH}-unknown-linux-musl.tar.gz"; \
+    curl -fL "$URL" -o /tmp/just.tar.gz; \
+    mkdir -p /tmp/just; \
+    tar -xzf /tmp/just.tar.gz -C /tmp/just; \
+    mv /tmp/just/just /usr/local/bin/just; \
+    chmod +x /usr/local/bin/just; \
+    rm -rf /tmp/just.tar.gz /tmp/just; \
+    just --version
 
 # ---- Language Servers + AI CLIs --------------------------------------------
 ARG AI_TOOLS_CACHE_BUST=stable
@@ -281,6 +330,15 @@ if [ -n "${HOST_HOME:-}" ]; then
 
   export HOME="${HOST_HOME}"
 
+  # Rust: persist the crate registry/cache to the bind-mounted ~/.cargo. The
+  # rustup proxy binaries live in /opt/rust/cargo/bin (already on PATH via the
+  # image ENV) and RUSTUP_HOME stays /opt/rust/rustup, so redirecting CARGO_HOME
+  # only moves the downloaded/registry cache, not the toolchain itself.
+  export CARGO_HOME="${HOST_HOME}/.cargo"
+  mkdir -p "${CARGO_HOME}/bin"
+  chown -R dev:dev "${CARGO_HOME}" 2>/dev/null || true
+  export PATH="${CARGO_HOME}/bin:$PATH"
+
   # Create container-side symlink to ~/.claude.json in shared directory
   # (Apple Containers can't bind-mount individual files, so we use symlinks)
   SHARED_CLAUDE_JSON="${HOST_HOME}/.claude-contained/.claude.json"
@@ -346,6 +404,7 @@ if [ "$(id -u)" = "0" ] && [ "${STAY_ROOT:-}" != "1" ]; then
     PATH="${USER_HOME}/.local/bin:$PATH" \
     HOME="$USER_HOME" \
     DISPLAY="$DISPLAY" \
+    ${CARGO_HOME:+CARGO_HOME="$CARGO_HOME"} \
     "$@"
 else
   # Also update PATH for root/non-gosu case

--- a/claude-contained
+++ b/claude-contained
@@ -31,7 +31,7 @@ Behavior:
   - Additional directories are automatically added via --add-dir (claude, codex only).
   - Append :ro to an extra dir to mount it read-only (or :rw to force read-write).
     The working directory cannot be read-only.
-  - Tool configs (~/.claude, ~/.codex, ~/.copilot, ~/.gemini, ~/.vibe), Maven cache (~/.m2), and Vaadin state (~/.vaadin) are bind-mounted.
+  - Tool configs (~/.claude, ~/.codex, ~/.copilot, ~/.gemini, ~/.vibe), Maven cache (~/.m2), Vaadin state (~/.vaadin), and Cargo cache (~/.cargo) are bind-mounted.
   - --share-skills=DIR mounts DIR as each tool's skills directory.
     For Codex, ~/.codex/skills/.system is mounted back over DIR/.system
     so built-in skills remain visible while new installs write to DIR.
@@ -851,10 +851,11 @@ HOST_COPILOT_DIR="${HOST_HOME}/.copilot"
 HOST_VIBE_DIR="${HOST_HOME}/.vibe"
 HOST_M2_DIR="${HOST_HOME}/.m2"
 HOST_VAADIN_DIR="${HOST_HOME}/.vaadin"
+HOST_CARGO_DIR="${HOST_HOME}/.cargo"
 HOST_GITCONFIG="${HOST_HOME}/.gitconfig"
 
 # Ensure persistent directories exist on host
-mkdir -p "${HOST_CLAUDE_DIR}" "${HOST_CODEX_DIR}" "${HOST_COPILOT_DIR}" "${HOST_GEMINI_DIR}" "${HOST_VIBE_DIR}" "${HOST_M2_DIR}" "${HOST_VAADIN_DIR}"
+mkdir -p "${HOST_CLAUDE_DIR}" "${HOST_CODEX_DIR}" "${HOST_COPILOT_DIR}" "${HOST_GEMINI_DIR}" "${HOST_VIBE_DIR}" "${HOST_M2_DIR}" "${HOST_VAADIN_DIR}" "${HOST_CARGO_DIR}"
 
 # Build container args
 CLAUDE_MEMORY="${CLAUDE_MEMORY:-8g}"
@@ -904,6 +905,7 @@ container_argv=(
   --mount "type=bind,src=${HOST_VIBE_DIR},dst=${HOST_HOME}/.vibe"
   --mount "type=bind,src=${HOST_M2_DIR},dst=${HOST_HOME}/.m2"
   --mount "type=bind,src=${HOST_VAADIN_DIR},dst=${HOST_HOME}/.vaadin"
+  --mount "type=bind,src=${HOST_CARGO_DIR},dst=${HOST_HOME}/.cargo"
   --mount "type=bind,src=${main_host},dst=${main_host}"
 )
 

--- a/claude-docked
+++ b/claude-docked
@@ -31,7 +31,7 @@ Behavior:
   - Additional directories are automatically added via --add-dir (claude, codex only).
   - Append :ro to an extra dir to mount it read-only (or :rw to force read-write).
     The working directory cannot be read-only.
-  - Tool configs (~/.claude, ~/.codex, ~/.copilot, ~/.gemini, ~/.vibe), Maven cache (~/.m2), and Vaadin state (~/.vaadin) are bind-mounted.
+  - Tool configs (~/.claude, ~/.codex, ~/.copilot, ~/.gemini, ~/.vibe), Maven cache (~/.m2), Vaadin state (~/.vaadin), and Cargo cache (~/.cargo) are bind-mounted.
   - --share-skills=DIR mounts DIR as each tool's skills directory.
     For Codex, ~/.codex/skills/.system is mounted back over DIR/.system
     so built-in skills remain visible while new installs write to DIR.
@@ -858,10 +858,11 @@ HOST_COPILOT_DIR="${HOST_HOME}/.copilot"
 HOST_VIBE_DIR="${HOST_HOME}/.vibe"
 HOST_M2_DIR="${HOST_HOME}/.m2"
 HOST_VAADIN_DIR="${HOST_HOME}/.vaadin"
+HOST_CARGO_DIR="${HOST_HOME}/.cargo"
 HOST_GITCONFIG="${HOST_HOME}/.gitconfig"
 
 # Ensure persistent directories exist on host
-mkdir -p "${HOST_CLAUDE_DIR}" "${HOST_CODEX_DIR}" "${HOST_COPILOT_DIR}" "${HOST_GEMINI_DIR}" "${HOST_VIBE_DIR}" "${HOST_M2_DIR}" "${HOST_VAADIN_DIR}"
+mkdir -p "${HOST_CLAUDE_DIR}" "${HOST_CODEX_DIR}" "${HOST_COPILOT_DIR}" "${HOST_GEMINI_DIR}" "${HOST_VIBE_DIR}" "${HOST_M2_DIR}" "${HOST_VAADIN_DIR}" "${HOST_CARGO_DIR}"
 
 # Build container args
 CLAUDE_MEMORY="${CLAUDE_MEMORY:-8g}"
@@ -911,6 +912,7 @@ container_argv=(
   --mount "type=bind,src=${HOST_VIBE_DIR},dst=${HOST_HOME}/.vibe"
   --mount "type=bind,src=${HOST_M2_DIR},dst=${HOST_HOME}/.m2"
   --mount "type=bind,src=${HOST_VAADIN_DIR},dst=${HOST_HOME}/.vaadin"
+  --mount "type=bind,src=${HOST_CARGO_DIR},dst=${HOST_HOME}/.cargo"
   --mount "type=bind,src=${main_host},dst=${main_host}"
 )
 


### PR DESCRIPTION
Rust projects run inside the container previously failed because no cargo/rustc/just was available (couldn't build, test, or generate insta snapshots). Install rustup (minimal + clippy + rustfmt) to a shared /opt/rust and a prebuilt just binary. Add build-essential + pkg-config so cargo has a C linker (cc/ld) and can build crates that link C libraries. Redirect CARGO_HOME to a bind-mounted ~/.cargo (mirroring ~/.m2) so the crate registry persists across runs; rustup proxies stay on PATH and RUSTUP_HOME stays baked in.